### PR TITLE
replaced depreciated np.int() with int() at line 6 in Dither.py

### DIFF
--- a/Dither.py
+++ b/Dither.py
@@ -3,7 +3,7 @@ import numpy as np
 class ditherModule(object):
     def dither(self, img, method='floyd-steinberg', resize = False):
         if(resize):
-            img = cv2.resize(img, (np.int(0.5*(np.shape(img)[1])), np.int(0.5*(np.shape(img)[0]))))
+            img = cv2.resize(img, (int(0.5*(np.shape(img)[1])), int(0.5*(np.shape(img)[0]))))
         if(method == 'simple2D'):
             img = cv2.copyMakeBorder(img, 1, 1, 1, 1, cv2.BORDER_REPLICATE)
             rows, cols = np.shape(img)

--- a/main.py
+++ b/main.py
@@ -8,4 +8,4 @@ if __name__ == '__main__':
 
     out = Dither.dither(img, 'simple2D', resize=True)  # perform image dithering
     cv2.imshow('dithered image', out)
-    cv2.waitKey(0);
+    cv2.waitKey(0)


### PR DESCRIPTION
Hey I was getting an error while running your library that np.int is no longer supported so i changed it to just int()
The Error: 
-------------------------------------------------------------------
File "C:\Users\rrath\Desktop\my projects\PythonDithering\Dither.py", line 6, in dither
    img = cv2.resize(img, (np.int(0.5*(np.shape(img)[1])), np.int(0.5*(np.shape(img)[0]))))
                           ^^^^^^
  File "C:\Users\rrath\AppData\Local\Programs\Python\Python311\Lib\site-packages\numpy\__init__.py", line 338, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
---------------------------------------------------------------------------------------------------